### PR TITLE
fix: add explicit error for missing router return in controllers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @psenger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.1.0](https://github.com/psenger/express-auto-router/compare/v0.0.3...v0.1.0) (2025-03-17)
+
+
+### Features
+
+* pass parameters to the controllers and middleware ([81994e1](https://github.com/psenger/express-auto-router/commit/81994e112152edd9687429db115373b014ff651e))
+
 ### [0.0.3](https://github.com/psenger/express-auto-router/compare/v0.0.2...v0.0.3) (2025-03-14)
 
 

--- a/HOWITWORKS.md
+++ b/HOWITWORKS.md
@@ -54,7 +54,37 @@ export function isMiddlewareFile(entry) {
 The system expects middleware files to be named exactly `_middleware.js`.
 
 3. **Hierarchical Middleware Organization**
-The `dictionaryKeyStartsWithPath` function enforces a hierarchical middleware structure, sorting by path length to ensure proper execution order.
+The `dictionaryKeyStartsWithPath` function enforces a hierarchical middleware structure, sorting by path length to ensure proper execution order. Please note this is an opinion of how middleware should work and is baked into this system. If you want to control this it would have to be done inside the middleware.
+
+4. **Parameter calls**
+
+Global parameters/options can be passed to the controllers and middleware like this
+
+```javascript
+
+const middlewareOptions = { logLevel: debug }
+const controllerOptions = { env: 'test' }
+composeRoutes(express, routeMappings, { middlewareOptions, controllerOptions } )
+```
+
+You should write your Controllers like this.
+
+```javascript
+module.exports = ( router, controllerOptions ) => {
+  ...
+  return router
+}
+```
+
+You should write your Middleware like this.
+
+```javascript
+module.exports = ( middlewareOptions ) => {
+  return [
+    ...
+  ]
+}
+```
 
 ## Potential Issues and Considerations
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@psenger/express-auto-router",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@psenger/express-auto-router",
-      "version": "0.0.3",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@psenger/markdown-fences": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psenger/express-auto-router",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "A dynamic route composition system for Express.js applications that automatically discovers and mount routes and middleware based on your file system structure. Inspired by Next.js routing conventions.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/index.js
+++ b/src/index.js
@@ -270,6 +270,7 @@ export function curryObjectMethods(
  *
  * @param {string} basePath - Base filesystem path to start scanning
  * @param {string} baseURL - Base URL path for the routes
+ * @param {Object} [options=undefined] - Options that can be passed to all controllers when they are executed.
  * @returns {Object<string, Array<Function>>} Dictionary where keys are URL paths and values are arrays of middleware functions
  *
  * @example
@@ -308,7 +309,7 @@ export function curryObjectMethods(
  * //   '/api/': [singleMiddleware]
  * // }
  */
-export function buildMiddlewareDictionary(basePath, baseURL) {
+export function buildMiddlewareDictionary(basePath, baseURL, options) {
   const dictionary = {}
   const traverseDirectory = (currentPath, currentURL) => {
     const dirEntries = readdirSync(currentPath, { withFileTypes: true })
@@ -324,7 +325,7 @@ export function buildMiddlewareDictionary(basePath, baseURL) {
         traverseDirectory(entryPath, entryURL)
       } else if (isMiddlewareFile(entry)) {
         try {
-          const middleware = require(entryPath)()
+          const middleware = require(entryPath)(options)
           const middlewareURL = entryURL.replace('_middleware.js', '')
           dictionary[middlewareURL] = autoBox(middleware)
         } catch (e) {
@@ -418,6 +419,8 @@ export function buildRoutes(basePath, baseURL) {
  * @param {string} routeMappings[].baseURL - Base URL path for the routes
  * @param {Object} [options] - Configuration options
  * @param {Object} [options.routerOptions] - Options for the Express router (default: `{ strict: true }` stay with this for best results but be advised it makes paths require to be terminated with `/` )
+ * @param {Object} [options.middlewareOptions=undefined] - Options passed to every middleware.
+ * @param {Object} [options.controllerOptions=undefined] - Options passed to every controller.
  * @returns {Object} Configured Express router with applied routes
  *
  * @example
@@ -458,7 +461,6 @@ export function buildRoutes(basePath, baseURL) {
  * ], {
  *   routerOptions: {
  *     strict: true,
- *     caseSensitive: true
  *   }
  * });
  *
@@ -477,19 +479,22 @@ export function buildRoutes(basePath, baseURL) {
 const composeRoutes = (
   express,
   routeMappings,
-  options = { routerOptions: { strict: true } }
+  options = { routerOptions: { strict: true }, middlewareOptions: undefined, controllerOptions: undefined }
 ) => {
   if (!Array.isArray(routeMappings)) {
     throw new Error('Route mappings must be an array')
   }
   const routerOptions = options.routerOptions || { strict: true }
+  const middlewareOptions = options.middlewareOptions || undefined
+  const controllerOptions = options.controllerOptions || undefined
   const router = express.Router(routerOptions)
   return routeMappings.reduce((router, { basePath, baseURL }) => {
     validatePath(basePath)
     validatePath(baseURL)
     const middlewareFunctionDictionary = buildMiddlewareDictionary(
       basePath,
-      baseURL
+      baseURL,
+      middlewareOptions
     )
     const routes = buildRoutes(basePath, baseURL)
     routes.map(([url, filepath]) => {
@@ -500,7 +505,7 @@ const composeRoutes = (
         ...dictionaryKeyStartsWithPath(middlewareFunctionDictionary, url)
       )
       const controllers = require(filepath)
-      curriedRouter = controllers(curriedRouter)
+      curriedRouter = controllers(curriedRouter, controllerOptions)
       router = curriedRouter._getOriginalObject()
     })
     return router

--- a/src/index.js
+++ b/src/index.js
@@ -497,7 +497,7 @@ const composeRoutes = (
       middlewareOptions
     )
     const routes = buildRoutes(basePath, baseURL)
-    routes.map(([url, filepath]) => {
+    routes.forEach(([url, filepath]) => {
       // curry the Router, so that the URL is set to the route, and the Middleware is loaded.
       let curriedRouter = curryObjectMethods(
         router,
@@ -506,6 +506,9 @@ const composeRoutes = (
       )
       const controllers = require(filepath)
       curriedRouter = controllers(curriedRouter, controllerOptions)
+      if ( ! curriedRouter ) {
+        throw new Error(`Controller at ${filepath} did not return the 'router'`)
+      }
       router = curriedRouter._getOriginalObject()
     })
     return router

--- a/test/dynamic-routes.spec.js
+++ b/test/dynamic-routes.spec.js
@@ -1,5 +1,9 @@
 const request = require('supertest')
 const app = require('./app')
+const composeRoutes = require('../dist/index').default
+const express = require('express')
+const { join } = require('path')
+
 function replaceRouteParams(routeString, paramsObject) {
   const placeholderRegex = /\[([^\]]+)\]/g
   const paramNames = [...new Set(
@@ -58,4 +62,20 @@ describe('Express API Routes', () => {
       expect(response.body).toEqual({ route: convertPlaceholderFormat(route), params })
     }
   )
+})
+
+describe('Controller Error Handling', () => {
+  it('should throw error when controller does not return router', () => {
+    const testApp = express()
+    const routeMappings = [
+      {
+        basePath: join(process.cwd(), 'test', 'routes', 'designed-to-fail', 'no-router-return'),
+        baseURL: '/invalid'
+      }
+    ]
+    
+    expect(() => {
+      testApp.use('/api', composeRoutes(express, routeMappings))
+    }).toThrow('Controller at')
+  })
 })

--- a/test/routes/designed-to-fail/no-router-return/index.js
+++ b/test/routes/designed-to-fail/no-router-return/index.js
@@ -1,0 +1,10 @@
+const standard_controllers = (req, res, _next) => res.status(200).send({route: `${req.baseUrl}${req.route.path}`, params: req.params})
+
+module.exports = ( router ) => {
+  router.get(standard_controllers)
+  router.post(standard_controllers)
+  router.put(standard_controllers)
+  router.patch(standard_controllers)
+  router.delete(standard_controllers)
+  // Intentionally not returning the router to test error case
+} 


### PR DESCRIPTION
# Missing router Return Causes Unclear Exception

When a controller doesn't return the router object, the error was unclear and
pointed to an internal implementation detail (_getOriginalObject). This change
adds explicit validation to check if the router is returned and provides a
clear error message indicating which controller file failed to return the router.

- Add validation check in composeRoutes to verify router is returned
- Add descriptive error message that includes the controller file path
- Add test case in designed-to-fail directory to verify error handling
- Remove internal implementation details from error message

Fixes #1